### PR TITLE
scan2archive: make it default to python3

### DIFF
--- a/src/scan2archive/scan2archive.py
+++ b/src/scan2archive/scan2archive.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # @author Thomas Gubler <thomasgubler@gmail.com>
 # License: GPLv3, see LICENSE.txt


### PR DESCRIPTION
Otherwise I can't use it on Ubuntu because python still points to
Python 2.7.